### PR TITLE
JSON options

### DIFF
--- a/src/Message/Event.php
+++ b/src/Message/Event.php
@@ -148,7 +148,8 @@ class Event extends EventAbstract
                 'idfa' => $this->getIdfa(),
                 'adid' => $this->getAdid(),
                 'session_id' => $this->getSessionId(),
-            )
+            ),
+            JSON_FORCE_OBJECT
         );
     }
 


### PR DESCRIPTION
The solution to the problem: empty 'event_properties' is converted to the wrong json-string and causes an error:
"invalid_event_field. Invalid fields [event_properties]."